### PR TITLE
Support straming using io.Writer

### DIFF
--- a/crc24.go
+++ b/crc24.go
@@ -1,4 +1,12 @@
+// Package crc24 implements the 24-bit cyclic redundancy check, or CRC-24,
+// checksum. See http://en.wikipedia.org/wiki/Cyclic_redundancy_check for
+// information.
 package crc24
+
+import "hash"
+
+// The size of a CRC-24 checksum in bytes.
+const Size = 3
 
 const (
 	crc24Init = 0xb704ce
@@ -6,14 +14,49 @@ const (
 	crc24Mask = 0xffffff
 )
 
-// ChecksumOpenPGP calculates the crc-24 as used by OpenPGP
-func ChecksumOpenPGP(p []byte) uint32 {
-
-	return crc24(0, p)
+// Hash24 is the common interface for a 24-bit hash function.
+type Hash24 interface {
+	hash.Hash
+	Sum24() uint32
 }
 
-// crc24 calculates the OpenPGP checksum as specified in RFC 4880, section 6.1
-func crc24(crc uint32, d []byte) uint32 {
+// digest represents the partial evaluation of a checksum.
+type digest struct {
+	crc uint32
+}
+
+func (d *digest) Size() int { return Size }
+
+func (d *digest) BlockSize() int { return 1 }
+
+func (d *digest) Reset() { d.crc = 0 }
+
+func (d *digest) Sum24() uint32 { return d.crc }
+
+func (d *digest) Sum(in []byte) []byte {
+	s := d.Sum24()
+	return append(in, byte(s>>16), byte(s>>8), byte(s))
+}
+
+func (d *digest) Write(p []byte) (int, error) {
+	d.crc = Update(d.crc, p)
+	return len(p), nil
+}
+
+// New creates a new Hash24 computing the CRC-24 checksum.
+func New() Hash24 {
+	return &digest{0}
+}
+
+// ChecksumOpenPGP calculates the openPGP-24 as used by OpenPGP
+func ChecksumOpenPGP(p []byte) uint32 {
+	return Update(0, p)
+}
+
+// Update returns the result of adding the bytes in p to the openPGP.
+// It is compatible with OpenPGP checksum as specified in RFC 4880, section 6.1
+// (https://tools.ietf.org/html/rfc4880#section-6.1).
+func Update(crc uint32, d []byte) uint32 {
 	for _, b := range d {
 		crc ^= uint32(b) << 16
 		for i := 0; i < 8; i++ {

--- a/crc24_test.go
+++ b/crc24_test.go
@@ -1,16 +1,44 @@
 package crc24
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCrc24(t *testing.T) {
+type testCase struct {
+	openPGP uint32
+	in      []byte
+}
 
-	d1 := []byte{1, 2, 3, 4, 5, 6}
-	assert.Equal(t, uint32(0xbc7e06), ChecksumOpenPGP(d1))
+var tests = []testCase{
+	{0x0, []byte{}},
+	{0x0, []byte{0}},
+	{0x0, []byte{0, 0}},
+	{0xbc7e06, []byte{1, 2, 3, 4, 5, 6}},
+}
 
-	d2 := []byte{0, 0, 0, 0}
-	assert.Equal(t, uint32(0), ChecksumOpenPGP(d2))
+func TestUpdate(t *testing.T) {
+	for _, tc := range tests {
+		assert.Equal(t, tc.openPGP, Update(0, tc.in))
+	}
+}
+
+func TestChecksumOpenPGP(t *testing.T) {
+	for _, tc := range tests {
+		assert.Equal(t, tc.openPGP, ChecksumOpenPGP(tc.in))
+	}
+}
+
+func TestDigest(t *testing.T) {
+	for _, tc := range tests {
+		digest := New()
+		n, _ := digest.Write(tc.in)
+		assert.Equal(t, len(tc.in), n, "Written bytes should match the input length.")
+		assert.Equal(t, tc.openPGP, digest.Sum24())
+		sum := make([]byte, 4)
+		binary.BigEndian.PutUint32(sum, tc.openPGP)
+		assert.Equal(t, append(tc.in, sum[1:]...), digest.Sum(tc.in))
+	}
 }


### PR DESCRIPTION
PR for #1.

There is hardly any original code left. For that I am somewhat sorry. 

I have made the following design decisions:

- Keep the current API;
- Follow the example of `hash`, `hash/crc32` and `hash/crc64`.

I would have preferred to add more — especially longer — test cases but I could not find a source of verified CRC-24s.